### PR TITLE
feature/お気に入りフォルダ機能を実装

### DIFF
--- a/Sources/ClipboardItem.swift
+++ b/Sources/ClipboardItem.swift
@@ -1,17 +1,97 @@
 import Foundation
 
+/// カテゴリのデータモデル
+struct Category: Codable, Identifiable, Equatable {
+    let id: UUID
+    let name: String
+    let color: String // カラーコード（例: "#FF0000"）
+    let isDefault: Bool // デフォルトカテゴリかどうか
+    
+    init(name: String, color: String = "#007AFF", isDefault: Bool = false) {
+        self.id = UUID()
+        self.name = name
+        self.color = color
+        self.isDefault = isDefault
+    }
+    
+    // デフォルトカテゴリ
+    static let defaultCategory = Category(name: "一般", color: "#007AFF", isDefault: true)
+    
+    // プリセットカテゴリ
+    static let presetCategories: [Category] = [
+        Category(name: "一般", color: "#007AFF", isDefault: true),
+        Category(name: "URL", color: "#34C759", isDefault: true),
+        Category(name: "コード", color: "#FF9500", isDefault: true),
+        Category(name: "パスワード", color: "#FF3B30", isDefault: true),
+        Category(name: "メモ", color: "#FFCC00", isDefault: true)
+    ]
+}
+
+/// お気に入りフォルダのデータモデル
+struct FavoriteFolder: Codable, Identifiable, Equatable {
+    let id: UUID
+    let name: String
+    let color: String // カラーコード
+    let isDefault: Bool // デフォルトフォルダかどうか
+    let createdAt: Date
+    
+    init(name: String, color: String = "#FF6B6B", isDefault: Bool = false) {
+        self.id = UUID()
+        self.name = name
+        self.color = color
+        self.isDefault = isDefault
+        self.createdAt = Date()
+    }
+    
+    // デフォルトフォルダ
+    static let defaultFolder = FavoriteFolder(name: "お気に入り", color: "#FF6B6B", isDefault: true)
+    
+    // プリセットフォルダ
+    static let presetFolders: [FavoriteFolder] = [
+        FavoriteFolder(name: "お気に入り", color: "#FF6B6B", isDefault: true),
+        FavoriteFolder(name: "よく使う", color: "#4ECDC4", isDefault: true),
+        FavoriteFolder(name: "重要", color: "#45B7D1", isDefault: true),
+        FavoriteFolder(name: "一時保存", color: "#96CEB4", isDefault: true)
+    ]
+}
+
 /// クリップボードアイテムのデータモデル
 struct ClipboardItem: Codable, Identifiable, Equatable {
     let id: UUID
     let content: String
     let timestamp: Date
     let isFavorite: Bool
+    let categoryId: UUID // カテゴリのID
+    let favoriteFolderId: UUID? // お気に入りフォルダのID（お気に入りの場合のみ）
     
-    init(content: String, isFavorite: Bool = false) {
+    init(content: String, isFavorite: Bool = false, categoryId: UUID? = nil, favoriteFolderId: UUID? = nil) {
         self.id = UUID()
         self.content = content
         self.timestamp = Date()
         self.isFavorite = isFavorite
+        self.categoryId = categoryId ?? Category.defaultCategory.id
+        self.favoriteFolderId = favoriteFolderId
+    }
+    
+    // カスタムデコーダー（既存データとの互換性のため）
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        id = try container.decode(UUID.self, forKey: .id)
+        content = try container.decode(String.self, forKey: .content)
+        timestamp = try container.decode(Date.self, forKey: .timestamp)
+        isFavorite = try container.decode(Bool.self, forKey: .isFavorite)
+        
+        // categoryIdが存在しない場合はデフォルトカテゴリを使用
+        categoryId = try container.decodeIfPresent(UUID.self, forKey: .categoryId) ?? Category.defaultCategory.id
+        
+        // favoriteFolderIdが存在しない場合はnilを使用
+        favoriteFolderId = try container.decodeIfPresent(UUID.self, forKey: .favoriteFolderId)
+    }
+    
+    // コーディングキー
+    private enum CodingKeys: String, CodingKey {
+        case id, content, timestamp, isFavorite, categoryId, favoriteFolderId
     }
     
     /// 表示用の短縮テキスト（長すぎる場合は省略）
@@ -35,13 +115,35 @@ struct ClipboardItem: Codable, Identifiable, Equatable {
 class ClipboardDataManager: ObservableObject {
     @Published var historyItems: [ClipboardItem] = []
     @Published var favoriteItems: [ClipboardItem] = []
+    @Published var categories: [Category] = []
+    @Published var favoriteFolders: [FavoriteFolder] = []
     
     private let maxHistoryCount = 50
     private let historyKey = "ClipboardHistory"
     private let favoritesKey = "ClipboardFavorites"
+    private let categoriesKey = "ClipboardCategories"
+    private let favoriteFoldersKey = "FavoriteFolders"
     
     init() {
         loadData()
+        initializeDefaultCategories()
+        initializeDefaultFavoriteFolders()
+    }
+    
+    /// デフォルトカテゴリを初期化
+    private func initializeDefaultCategories() {
+        if categories.isEmpty {
+            categories = Category.presetCategories
+            saveData()
+        }
+    }
+    
+    /// デフォルトお気に入りフォルダを初期化
+    private func initializeDefaultFavoriteFolders() {
+        if favoriteFolders.isEmpty {
+            favoriteFolders = FavoriteFolder.presetFolders
+            saveData()
+        }
     }
     
     /// 新しいクリップボードアイテムを履歴に追加
@@ -66,10 +168,15 @@ class ClipboardDataManager: ObservableObject {
     }
     
     /// アイテムをお気に入りに追加
-    func addToFavorites(_ item: ClipboardItem) {
+    func addToFavorites(_ item: ClipboardItem, to folderId: UUID? = nil) {
         // 既にお気に入りに存在するかチェック
         if !favoriteItems.contains(where: { $0.content == item.content }) {
-            let favoriteItem = ClipboardItem(content: item.content, isFavorite: true)
+            let favoriteItem = ClipboardItem(
+                content: item.content, 
+                isFavorite: true, 
+                categoryId: item.categoryId,
+                favoriteFolderId: folderId ?? FavoriteFolder.defaultFolder.id
+            )
             favoriteItems.append(favoriteItem)
             saveData()
         }
@@ -78,6 +185,20 @@ class ClipboardDataManager: ObservableObject {
     /// お気に入りからアイテムを削除
     func removeFromFavorites(_ item: ClipboardItem) {
         favoriteItems.removeAll { $0.id == item.id }
+        saveData()
+    }
+    
+    /// お気に入りアイテムのフォルダを変更
+    func changeFavoriteFolder(_ item: ClipboardItem, to folderId: UUID) {
+        guard let index = favoriteItems.firstIndex(where: { $0.id == item.id }) else { return }
+        
+        let updatedItem = ClipboardItem(
+            content: item.content,
+            isFavorite: item.isFavorite,
+            categoryId: item.categoryId,
+            favoriteFolderId: folderId
+        )
+        favoriteItems[index] = updatedItem
         saveData()
     }
     
@@ -99,14 +220,168 @@ class ClipboardDataManager: ObservableObject {
         saveData()
     }
     
+    // MARK: - カテゴリ管理
+    
+    /// カスタムカテゴリを追加
+    func addCategory(name: String, color: String = "#007AFF") {
+        let newCategory = Category(name: name, color: color, isDefault: false)
+        categories.append(newCategory)
+        saveData()
+    }
+    
+    /// カテゴリを削除
+    func deleteCategory(_ category: Category) {
+        // デフォルトカテゴリは削除できない
+        guard !category.isDefault else { return }
+        
+        // 削除するカテゴリのアイテムをデフォルトカテゴリに移動
+        let defaultCategoryId = Category.defaultCategory.id
+        for i in 0..<historyItems.count {
+            if historyItems[i].categoryId == category.id {
+                let updatedItem = ClipboardItem(
+                    content: historyItems[i].content,
+                    isFavorite: historyItems[i].isFavorite,
+                    categoryId: defaultCategoryId
+                )
+                historyItems[i] = updatedItem
+            }
+        }
+        
+        for i in 0..<favoriteItems.count {
+            if favoriteItems[i].categoryId == category.id {
+                let updatedItem = ClipboardItem(
+                    content: favoriteItems[i].content,
+                    isFavorite: favoriteItems[i].isFavorite,
+                    categoryId: defaultCategoryId
+                )
+                favoriteItems[i] = updatedItem
+            }
+        }
+        
+        categories.removeAll { $0.id == category.id }
+        saveData()
+    }
+    
+    /// カテゴリを更新
+    func updateCategory(_ category: Category, name: String, color: String) {
+        guard let index = categories.firstIndex(where: { $0.id == category.id }) else { return }
+        let updatedCategory = Category(name: name, color: color, isDefault: category.isDefault)
+        categories[index] = updatedCategory
+        saveData()
+    }
+    
+    /// アイテムのカテゴリを変更
+    func changeItemCategory(_ item: ClipboardItem, to categoryId: UUID) {
+        let updatedItem = ClipboardItem(
+            content: item.content,
+            isFavorite: item.isFavorite,
+            categoryId: categoryId
+        )
+        
+        // 履歴から更新
+        if let index = historyItems.firstIndex(where: { $0.id == item.id }) {
+            historyItems[index] = updatedItem
+        }
+        
+        // お気に入りから更新
+        if let index = favoriteItems.firstIndex(where: { $0.id == item.id }) {
+            favoriteItems[index] = updatedItem
+        }
+        
+        saveData()
+    }
+    
+    /// カテゴリIDからカテゴリを取得
+    func getCategory(by id: UUID) -> Category {
+        return categories.first { $0.id == id } ?? Category.defaultCategory
+    }
+    
+    /// カテゴリ別にアイテムをグループ化
+    func getItemsByCategory() -> [UUID: [ClipboardItem]] {
+        var grouped: [UUID: [ClipboardItem]] = [:]
+        
+        for item in historyItems {
+            if grouped[item.categoryId] == nil {
+                grouped[item.categoryId] = []
+            }
+            grouped[item.categoryId]?.append(item)
+        }
+        
+        return grouped
+    }
+    
+    // MARK: - お気に入りフォルダ管理
+    
+    /// カスタムお気に入りフォルダを追加
+    func addFavoriteFolder(name: String, color: String = "#FF6B6B") {
+        let newFolder = FavoriteFolder(name: name, color: color, isDefault: false)
+        favoriteFolders.append(newFolder)
+        saveData()
+    }
+    
+    /// お気に入りフォルダを削除
+    func deleteFavoriteFolder(_ folder: FavoriteFolder) {
+        // デフォルトフォルダは削除できない
+        guard !folder.isDefault else { return }
+        
+        // 削除するフォルダのアイテムをデフォルトフォルダに移動
+        let defaultFolderId = FavoriteFolder.defaultFolder.id
+        for i in 0..<favoriteItems.count {
+            if favoriteItems[i].favoriteFolderId == folder.id {
+                let updatedItem = ClipboardItem(
+                    content: favoriteItems[i].content,
+                    isFavorite: favoriteItems[i].isFavorite,
+                    categoryId: favoriteItems[i].categoryId,
+                    favoriteFolderId: defaultFolderId
+                )
+                favoriteItems[i] = updatedItem
+            }
+        }
+        
+        favoriteFolders.removeAll { $0.id == folder.id }
+        saveData()
+    }
+    
+    /// お気に入りフォルダを更新
+    func updateFavoriteFolder(_ folder: FavoriteFolder, name: String, color: String) {
+        guard let index = favoriteFolders.firstIndex(where: { $0.id == folder.id }) else { return }
+        let updatedFolder = FavoriteFolder(name: name, color: color, isDefault: folder.isDefault)
+        favoriteFolders[index] = updatedFolder
+        saveData()
+    }
+    
+    /// お気に入りフォルダIDからフォルダを取得
+    func getFavoriteFolder(by id: UUID) -> FavoriteFolder {
+        return favoriteFolders.first { $0.id == id } ?? FavoriteFolder.defaultFolder
+    }
+    
+    /// お気に入りフォルダ別にアイテムをグループ化
+    func getFavoritesByFolder() -> [UUID: [ClipboardItem]] {
+        var grouped: [UUID: [ClipboardItem]] = [:]
+        
+        for item in favoriteItems {
+            let folderId = item.favoriteFolderId ?? FavoriteFolder.defaultFolder.id
+            if grouped[folderId] == nil {
+                grouped[folderId] = []
+            }
+            grouped[folderId]?.append(item)
+        }
+        
+        return grouped
+    }
+    
     /// データをUserDefaultsに保存
     private func saveData() {
         do {
             let historyData = try JSONEncoder().encode(historyItems)
             let favoritesData = try JSONEncoder().encode(favoriteItems)
+            let categoriesData = try JSONEncoder().encode(categories)
+            let favoriteFoldersData = try JSONEncoder().encode(favoriteFolders)
             
             UserDefaults.standard.set(historyData, forKey: historyKey)
             UserDefaults.standard.set(favoritesData, forKey: favoritesKey)
+            UserDefaults.standard.set(categoriesData, forKey: categoriesKey)
+            UserDefaults.standard.set(favoriteFoldersData, forKey: favoriteFoldersKey)
         } catch {
             print("データの保存に失敗しました: \(error)")
         }
@@ -122,8 +397,21 @@ class ClipboardDataManager: ObservableObject {
             if let favoritesData = UserDefaults.standard.data(forKey: favoritesKey) {
                 favoriteItems = try JSONDecoder().decode([ClipboardItem].self, from: favoritesData)
             }
+            
+            if let categoriesData = UserDefaults.standard.data(forKey: categoriesKey) {
+                categories = try JSONDecoder().decode([Category].self, from: categoriesData)
+            }
+            
+            if let favoriteFoldersData = UserDefaults.standard.data(forKey: favoriteFoldersKey) {
+                favoriteFolders = try JSONDecoder().decode([FavoriteFolder].self, from: favoriteFoldersData)
+            }
         } catch {
             print("データの読み込みに失敗しました: \(error)")
+            // エラーが発生した場合は既存データをクリアして新しく開始
+            historyItems = []
+            favoriteItems = []
+            categories = []
+            favoriteFolders = []
         }
     }
 }

--- a/Sources/ClipboardManager.swift
+++ b/Sources/ClipboardManager.swift
@@ -38,36 +38,61 @@ class ClipboardManager: ObservableObject {
         
         let menu = NSMenu()
         
-        // 履歴セクション
-        if !dataManager.historyItems.isEmpty {
+        // 履歴セクション（カテゴリ別表示）
+        let groupedItems = dataManager.getItemsByCategory()
+        if !groupedItems.isEmpty {
             let historyTitle = NSMenuItem(title: "直近のコピー履歴", action: nil, keyEquivalent: "")
             historyTitle.isEnabled = false
             menu.addItem(historyTitle)
             
-            // 履歴アイテムを追加（最大10件表示）
-            let displayCount = min(dataManager.historyItems.count, 10)
-            for i in 0..<displayCount {
-                let item = dataManager.historyItems[i]
-                let menuItem = NSMenuItem(title: item.displayText, action: #selector(copyToClipboard(_:)), keyEquivalent: "")
-                menuItem.target = self
-                menuItem.representedObject = item.content
-                menu.addItem(menuItem)
+            // カテゴリ別に表示
+            for category in dataManager.categories {
+                if let items = groupedItems[category.id], !items.isEmpty {
+                    // カテゴリ名を追加
+                    let categoryItem = NSMenuItem(title: "  📁 \(category.name)", action: nil, keyEquivalent: "")
+                    categoryItem.isEnabled = false
+                    menu.addItem(categoryItem)
+                    
+                    // そのカテゴリのアイテムを追加（最大5件）
+                    let displayCount = min(items.count, 5)
+                    for i in 0..<displayCount {
+                        let item = items[i]
+                        let menuItem = NSMenuItem(title: "    \(item.displayText)", action: #selector(copyToClipboard(_:)), keyEquivalent: "")
+                        menuItem.target = self
+                        menuItem.representedObject = item.content
+                        menu.addItem(menuItem)
+                    }
+                }
             }
             
             menu.addItem(NSMenuItem.separator())
         }
         
-        // お気に入りセクション
-        if !dataManager.favoriteItems.isEmpty {
+        // お気に入りセクション（フォルダ別表示）
+        let groupedFavorites = dataManager.getFavoritesByFolder()
+        if !groupedFavorites.isEmpty {
             let favoritesTitle = NSMenuItem(title: "お気に入り", action: nil, keyEquivalent: "")
             favoritesTitle.isEnabled = false
             menu.addItem(favoritesTitle)
             
-            for item in dataManager.favoriteItems {
-                let menuItem = NSMenuItem(title: item.displayText, action: #selector(copyToClipboard(_:)), keyEquivalent: "")
-                menuItem.target = self
-                menuItem.representedObject = item.content
-                menu.addItem(menuItem)
+            // フォルダ別に表示
+            for folder in dataManager.favoriteFolders {
+                if let items = groupedFavorites[folder.id], !items.isEmpty {
+                    // フォルダ名を追加
+                    let folderItem = NSMenuItem(title: "  📁 \(folder.name)", action: nil, keyEquivalent: "")
+                    folderItem.isEnabled = false
+                    menu.addItem(folderItem)
+                    
+                    // そのフォルダのアイテムを追加（最大5件）
+                    let displayCount = min(items.count, 5)
+                    for i in 0..<displayCount {
+                        let item = items[i]
+                        let menuItem = NSMenuItem(title: "    \(item.displayText)", action: #selector(copyToClipboard(_:)), keyEquivalent: "")
+                        menuItem.target = self
+                        menuItem.representedObject = item.content
+                        menu.addItem(menuItem)
+                    }
+                }
             }
             
             menu.addItem(NSMenuItem.separator())

--- a/Sources/HistoryView.swift
+++ b/Sources/HistoryView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 /// 履歴管理画面のSwiftUIビュー
 struct HistoryView: View {
@@ -6,6 +7,10 @@ struct HistoryView: View {
     @State private var searchText = ""
     @State private var selectedTab = 0
     @State private var showingClearAlert = false
+    @State private var selectedCategory: UUID? = nil
+    @State private var showingCategoryManager = false
+    @State private var selectedFavoriteFolder: UUID? = nil
+    @State private var showingFavoriteFolderManager = false
     
     var body: some View {
         VStack(spacing: 0) {
@@ -54,6 +59,30 @@ struct HistoryView: View {
                 
                 Spacer()
                 
+                // カテゴリフィルター
+                Menu {
+                    Button("すべてのカテゴリ") {
+                        selectedCategory = nil
+                    }
+                    
+                    ForEach(dataManager.categories) { category in
+                        Button(category.name) {
+                            selectedCategory = category.id
+                        }
+                    }
+                } label: {
+                    HStack {
+                        Image(systemName: "folder")
+                        Text(selectedCategory == nil ? "すべて" : dataManager.getCategory(by: selectedCategory!).name)
+                    }
+                }
+                .buttonStyle(PlainButtonStyle())
+                
+                Button("カテゴリ管理") {
+                    showingCategoryManager = true
+                }
+                .buttonStyle(PlainButtonStyle())
+                
                 Button("履歴をクリア") {
                     showingClearAlert = true
                 }
@@ -71,12 +100,19 @@ struct HistoryView: View {
                 List(filteredHistoryItems) { item in
                     HistoryItemRow(
                         item: item,
+                        category: dataManager.getCategory(by: item.categoryId),
                         onCopy: { copyToClipboard(item.content) },
                         onAddToFavorites: { dataManager.addToFavorites(item) },
-                        onDelete: { dataManager.removeFromHistory(item) }
+                        onDelete: { dataManager.removeFromHistory(item) },
+                        onChangeCategory: { categoryId in
+                            dataManager.changeItemCategory(item, to: categoryId)
+                        }
                     )
                 }
             }
+        }
+        .sheet(isPresented: $showingCategoryManager) {
+            CategoryManagerView(dataManager: dataManager)
         }
         .alert("履歴をクリア", isPresented: $showingClearAlert) {
             Button("キャンセル", role: .cancel) { }
@@ -97,6 +133,30 @@ struct HistoryView: View {
                     .font(.headline)
                 
                 Spacer()
+                
+                // お気に入りフォルダフィルター
+                Menu {
+                    Button("すべてのフォルダ") {
+                        selectedFavoriteFolder = nil
+                    }
+                    
+                    ForEach(dataManager.favoriteFolders) { folder in
+                        Button(folder.name) {
+                            selectedFavoriteFolder = folder.id
+                        }
+                    }
+                } label: {
+                    HStack {
+                        Image(systemName: "folder")
+                        Text(selectedFavoriteFolder == nil ? "すべて" : dataManager.getFavoriteFolder(by: selectedFavoriteFolder!).name)
+                    }
+                }
+                .buttonStyle(PlainButtonStyle())
+                
+                Button("フォルダ管理") {
+                    showingFavoriteFolderManager = true
+                }
+                .buttonStyle(PlainButtonStyle())
             }
             .padding()
             
@@ -109,11 +169,18 @@ struct HistoryView: View {
                 List(filteredFavoriteItems) { item in
                     FavoriteItemRow(
                         item: item,
+                        folder: dataManager.getFavoriteFolder(by: item.favoriteFolderId ?? FavoriteFolder.defaultFolder.id),
                         onCopy: { copyToClipboard(item.content) },
-                        onDelete: { dataManager.removeFromFavorites(item) }
+                        onDelete: { dataManager.removeFromFavorites(item) },
+                        onChangeFolder: { folderId in
+                            dataManager.changeFavoriteFolder(item, to: folderId)
+                        }
                     )
                 }
             }
+        }
+        .sheet(isPresented: $showingFavoriteFolderManager) {
+            FavoriteFolderManagerView(dataManager: dataManager)
         }
     }
     
@@ -143,23 +210,37 @@ struct HistoryView: View {
     
     // MARK: - フィルタリング
     private var filteredHistoryItems: [ClipboardItem] {
-        if searchText.isEmpty {
-            return dataManager.historyItems
-        } else {
-            return dataManager.historyItems.filter { item in
+        var items = dataManager.historyItems
+        
+        // カテゴリフィルター
+        if let selectedCategory = selectedCategory {
+            items = items.filter { $0.categoryId == selectedCategory }
+        }
+        
+        // 検索フィルター
+        if !searchText.isEmpty {
+            items = items.filter { item in
                 item.content.localizedCaseInsensitiveContains(searchText)
             }
         }
+        
+        return items
     }
     
     private var filteredFavoriteItems: [ClipboardItem] {
-        if searchText.isEmpty {
-            return dataManager.favoriteItems
-        } else {
-            return dataManager.favoriteItems.filter { item in
-                item.content.localizedCaseInsensitiveContains(searchText)
-            }
+        var items = dataManager.favoriteItems
+        
+        // お気に入りフォルダフィルター
+        if let selectedFavoriteFolder = selectedFavoriteFolder {
+            items = items.filter { $0.favoriteFolderId == selectedFavoriteFolder }
         }
+        
+        // 検索フィルター
+        if !searchText.isEmpty {
+            items = items.filter { $0.content.localizedCaseInsensitiveContains(searchText) }
+        }
+        
+        return items.sorted { $0.timestamp > $1.timestamp }
     }
     
     // MARK: - アクション
@@ -173,13 +254,28 @@ struct HistoryView: View {
 // MARK: - 履歴アイテム行
 struct HistoryItemRow: View {
     let item: ClipboardItem
+    let category: Category
     let onCopy: () -> Void
     let onAddToFavorites: () -> Void
     let onDelete: () -> Void
+    let onChangeCategory: (UUID) -> Void
     
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
             VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    // カテゴリバッジ
+                    Text(category.name)
+                        .font(.caption)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 2)
+                        .background(Color(hex: category.color).opacity(0.2))
+                        .foregroundColor(Color(hex: category.color))
+                        .cornerRadius(4)
+                    
+                    Spacer()
+                }
+                
                 Text(item.content)
                     .font(.body)
                     .lineLimit(3)
@@ -204,6 +300,19 @@ struct HistoryItemRow: View {
                 .buttonStyle(PlainButtonStyle())
                 .help("お気に入りに追加")
                 
+                Menu {
+                    Text("カテゴリを変更")
+                    ForEach([Category.defaultCategory] + Category.presetCategories.filter { $0.id != category.id }) { cat in
+                        Button(cat.name) {
+                            onChangeCategory(cat.id)
+                        }
+                    }
+                } label: {
+                    Image(systemName: "folder")
+                }
+                .buttonStyle(PlainButtonStyle())
+                .help("カテゴリを変更")
+                
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                 }
@@ -219,24 +328,58 @@ struct HistoryItemRow: View {
 // MARK: - お気に入りアイテム行
 struct FavoriteItemRow: View {
     let item: ClipboardItem
+    let folder: FavoriteFolder
     let onCopy: () -> Void
     let onDelete: () -> Void
+    let onChangeFolder: (UUID) -> Void
     
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
             VStack(alignment: .leading, spacing: 4) {
-                Text(item.content)
-                    .font(.body)
-                    .lineLimit(3)
+                HStack {
+                    Text(item.content)
+                        .font(.body)
+                        .lineLimit(3)
+                    
+                    Spacer()
+                    
+                    // フォルダバッジ
+                    HStack(spacing: 4) {
+                        Circle()
+                            .fill(Color(hex: folder.color))
+                            .frame(width: 8, height: 8)
+                        Text(folder.name)
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Color.gray.opacity(0.1))
+                    .cornerRadius(4)
+                }
                 
-                Text("お気に入り")
+                Text(item.timestamp, style: .time)
                     .font(.caption)
-                    .foregroundColor(.orange)
+                    .foregroundColor(.secondary)
             }
             
             Spacer()
             
             VStack(spacing: 4) {
+                // フォルダ変更メニュー
+                Menu {
+                    ForEach([FavoriteFolder.defaultFolder]) { folder in
+                        Button(folder.name) {
+                            onChangeFolder(folder.id)
+                        }
+                    }
+                } label: {
+                    Image(systemName: "folder")
+                        .foregroundColor(.blue)
+                }
+                .buttonStyle(PlainButtonStyle())
+                .help("フォルダを変更")
+                
                 Button(action: onCopy) {
                     Image(systemName: "doc.on.doc")
                 }
@@ -252,6 +395,248 @@ struct FavoriteItemRow: View {
             }
         }
         .padding(.vertical, 4)
+    }
+}
+
+// MARK: - カテゴリ管理画面
+struct CategoryManagerView: View {
+    @ObservedObject var dataManager: ClipboardDataManager
+    @State private var newCategoryName = ""
+    @State private var newCategoryColor = "#007AFF"
+    @Environment(\.dismiss) private var dismiss
+    
+    let presetColors = ["#007AFF", "#34C759", "#FF9500", "#FF3B30", "#AF52DE", "#FFCC00", "#5AC8FA", "#FF2D92"]
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("カテゴリ管理")
+                .font(.title2)
+                .fontWeight(.bold)
+            
+            // 新しいカテゴリ追加
+            VStack(alignment: .leading, spacing: 10) {
+                Text("新しいカテゴリを追加")
+                    .font(.headline)
+                
+                HStack {
+                    TextField("カテゴリ名", text: $newCategoryName)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                    
+                    ColorPicker("色", selection: Binding(
+                        get: { Color(hex: newCategoryColor) },
+                        set: { newCategoryColor = $0.toHex() }
+                    ))
+                    .frame(width: 50)
+                    
+                    Button("追加") {
+                        if !newCategoryName.isEmpty {
+                            dataManager.addCategory(name: newCategoryName, color: newCategoryColor)
+                            newCategoryName = ""
+                            newCategoryColor = "#007AFF"
+                        }
+                    }
+                    .disabled(newCategoryName.isEmpty)
+                }
+            }
+            .padding()
+            .background(Color.gray.opacity(0.1))
+            .cornerRadius(8)
+            
+            // カテゴリ一覧
+            List {
+                ForEach(dataManager.categories) { category in
+                    HStack {
+                        Circle()
+                            .fill(Color(hex: category.color))
+                            .frame(width: 20, height: 20)
+                        
+                        Text(category.name)
+                        
+                        Spacer()
+                        
+                        if !category.isDefault {
+                            Button("削除") {
+                                dataManager.deleteCategory(category)
+                            }
+                            .foregroundColor(.red)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+            
+            HStack {
+                Spacer()
+                Button("閉じる") {
+                    dismiss()
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding()
+        .frame(width: 400, height: 500)
+    }
+}
+
+// MARK: - お気に入りフォルダ管理画面
+struct FavoriteFolderManagerView: View {
+    @ObservedObject var dataManager: ClipboardDataManager
+    @State private var newFolderName = ""
+    @State private var newFolderColor = "#FF6B6B"
+    @Environment(\.dismiss) private var dismiss
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            // ヘッダー
+            HStack {
+                Text("お気に入りフォルダ管理")
+                    .font(.title2)
+                    .fontWeight(.semibold)
+                
+                Spacer()
+                
+                Button("完了") {
+                    dismiss()
+                }
+                .buttonStyle(.borderedProminent)
+            }
+            .padding()
+            .background(Color(NSColor.controlBackgroundColor))
+            
+            Divider()
+            
+            // コンテンツ
+            VStack(spacing: 20) {
+                // 新しいフォルダ追加
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("新しいフォルダを追加")
+                        .font(.headline)
+                    
+                    HStack(spacing: 12) {
+                        TextField("フォルダ名を入力", text: $newFolderName)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(minWidth: 200)
+                        
+                        HStack(spacing: 8) {
+                            Text("色:")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                            
+                            ColorPicker("", selection: Binding(
+                                get: { Color(hex: newFolderColor) },
+                                set: { newFolderColor = $0.toHex() }
+                            ))
+                            .frame(width: 40, height: 30)
+                        }
+                        
+                        Button("追加") {
+                            if !newFolderName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                                dataManager.addFavoriteFolder(name: newFolderName.trimmingCharacters(in: .whitespacesAndNewlines), color: newFolderColor)
+                                newFolderName = ""
+                                newFolderColor = "#FF6B6B"
+                            }
+                        }
+                        .buttonStyle(.bordered)
+                        .disabled(newFolderName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+                }
+                .padding()
+                .background(Color.gray.opacity(0.05))
+                .cornerRadius(8)
+                
+                // フォルダ一覧
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("フォルダ一覧")
+                        .font(.headline)
+                    
+                    if dataManager.favoriteFolders.isEmpty {
+                        Text("フォルダがありません")
+                            .foregroundColor(.secondary)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    } else {
+                        List {
+                            ForEach(dataManager.favoriteFolders) { folder in
+                                HStack(spacing: 12) {
+                                    Circle()
+                                        .fill(Color(hex: folder.color))
+                                        .frame(width: 20, height: 20)
+                                    
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(folder.name)
+                                            .font(.body)
+                                        
+                                        if folder.isDefault {
+                                            Text("デフォルトフォルダ")
+                                                .font(.caption2)
+                                                .foregroundColor(.secondary)
+                                        }
+                                    }
+                                    
+                                    Spacer()
+                                    
+                                    if !folder.isDefault {
+                                        Button("削除") {
+                                            dataManager.deleteFavoriteFolder(folder)
+                                        }
+                                        .foregroundColor(.red)
+                                        .buttonStyle(.plain)
+                                    }
+                                }
+                                .padding(.vertical, 4)
+                            }
+                        }
+                        .listStyle(.plain)
+                    }
+                }
+                
+                Spacer()
+            }
+            .padding()
+        }
+        .frame(width: 600, height: 500)
+        .background(Color(NSColor.windowBackgroundColor))
+    }
+}
+
+// MARK: - Color拡張
+extension Color {
+    init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+        let a, r, g, b: UInt64
+        switch hex.count {
+        case 3: // RGB (12-bit)
+            (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
+        case 6: // RGB (24-bit)
+            (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
+        case 8: // ARGB (32-bit)
+            (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
+        default:
+            (a, r, g, b) = (1, 1, 1, 0)
+        }
+        
+        self.init(
+            .sRGB,
+            red: Double(r) / 255,
+            green: Double(g) / 255,
+            blue:  Double(b) / 255,
+            opacity: Double(a) / 255
+        )
+    }
+    
+    func toHex() -> String {
+        let nsColor = NSColor(self)
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        
+        nsColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        
+        let rgb: Int = (Int)(red * 255) << 16 | (Int)(green * 255) << 8 | (Int)(blue * 255) << 0
+        
+        return String(format: "#%06x", rgb)
     }
 }
 


### PR DESCRIPTION
## 📁 お気に入りフォルダ機能の実装

### 概要
お気に入りアイテムをフォルダ別に整理・管理できる機能を追加しました。

### 実装内容

#### データモデル
- `FavoriteFolder`構造体を追加
- `ClipboardItem`にお気に入りフォルダIDを追加
- 既存データとの互換性を保つカスタムデコーダー

#### 機能
- ✅ カスタムお気に入りフォルダの作成・削除
- ✅ プリセットフォルダ（お気に入り、よく使う、重要、一時保存）
- ✅ フォルダ別お気に入り表示（メニューバー）
- ✅ お気に入りアイテムのフォルダ変更
- ✅ フォルダ管理画面のUI改善
- ✅ データ永続化

#### UI改善
- フォルダ管理画面のレイアウト改善
- 文字入力フィールドの改善
- 完了ボタンでモーダルを閉じる機能
- フォルダ別の視覚的表示（アイコン・色）

### テスト方法
1. メニューバーから「履歴を管理...」を開く
2. 「お気に入り」タブで「フォルダ管理」をクリック
3. 新しいフォルダを作成
4. お気に入りアイテムをフォルダに分類
5. メニューバーでフォルダ別表示を確認

### 互換性
- 既存のデータは自動的にデフォルトフォルダに分類されます
- 既存の機能に影響はありません