### PR TITLE
feat: スニペット編集画面にフォルダ変更機能を追加

### DIFF
--- a/Sources/ClipboardItem.swift
+++ b/Sources/ClipboardItem.swift
@@ -31,7 +31,7 @@ struct Category: Codable, Identifiable, Equatable {
 struct FavoriteFolder: Codable, Identifiable, Equatable {
     let id: UUID
     let name: String
-    let color: String // カラーコード
+    var color: String // カラーコード
     let isDefault: Bool // デフォルトフォルダかどうか
     let createdAt: Date
     
@@ -48,9 +48,9 @@ struct FavoriteFolder: Codable, Identifiable, Equatable {
 
 /// クリップボードアイテムのデータモデル
 struct ClipboardItem: Codable, Identifiable, Equatable {
-    let id: UUID
+    var id: UUID
     let content: String
-    let timestamp: Date
+    var timestamp: Date
     let isFavorite: Bool
     let categoryId: UUID // カテゴリのID
     let favoriteFolderId: UUID? // お気に入りフォルダのID（お気に入りの場合のみ）
@@ -178,7 +178,8 @@ class ClipboardDataManager: ObservableObject {
                 content: item.content, 
                 isFavorite: true, 
                 categoryId: item.categoryId,
-                favoriteFolderId: folderId
+                favoriteFolderId: folderId,
+                description: item.description
             )
             favoriteItems.append(favoriteItem)
             saveData()
@@ -199,9 +200,22 @@ class ClipboardDataManager: ObservableObject {
             content: item.content,
             isFavorite: item.isFavorite,
             categoryId: item.categoryId,
-            favoriteFolderId: folderId
+            favoriteFolderId: folderId,
+            description: item.description
         )
         favoriteItems[index] = updatedItem
+        saveData()
+    }
+    
+    /// お気に入りアイテムを編集
+    func updateFavoriteItem(_ item: ClipboardItem) {
+        guard let index = favoriteItems.firstIndex(where: { $0.id == item.id }) else { 
+            print("編集エラー: アイテムが見つかりません (ID: \(item.id))")
+            return 
+        }
+        print("編集前の説明: '\(favoriteItems[index].description)'")
+        favoriteItems[index] = item
+        print("編集後の説明: '\(favoriteItems[index].description)'")
         saveData()
     }
     
@@ -319,6 +333,15 @@ class ClipboardDataManager: ObservableObject {
     func addFavoriteFolder(name: String, color: String = "#FF6B6B") {
         let newFolder = FavoriteFolder(name: name, color: color, isDefault: false)
         favoriteFolders.append(newFolder)
+        saveData()
+    }
+    
+    /// お気に入りフォルダの色を更新
+    func updateFavoriteFolderColor(_ folder: FavoriteFolder, to color: String) {
+        guard let index = favoriteFolders.firstIndex(where: { $0.id == folder.id }) else { return }
+        var updatedFolder = favoriteFolders[index]
+        updatedFolder.color = color
+        favoriteFolders[index] = updatedFolder
         saveData()
     }
     


### PR DESCRIPTION
## 概要
スニペット編集画面でフォルダ変更が可能になり、フォルダ色パレットも改善しました。

## 主な変更内容

### 新機能
- ✅ スニペット編集時にフォルダを変更可能
- ✅ 視覚的なフォルダ選択UI（色付き円 + フォルダ名）
- ✅ フォルダなしオプション

### UI改善
- ✅ フォルダ色パレットを明るい色12色に変更
- ✅ フォルダ一覧から色変更機能を削除してシンプル化
- ✅ 編集開始時に現在のフォルダIDを初期化

### 技術的変更
- `SnippetItemRow`に`dataManager`パラメータを追加
- `FolderColorPalette`で12色の明るい色を定義
- `updateFavoriteFolderColor`メソッドを追加
- `FavoriteFolder.color`を`var`に変更

## テスト方法
1. スニペットタブを選択
2. 任意のスニペットの編集ボタンをクリック
3. フォルダ選択でドロップダウンから選択
4. 保存ボタンで変更を適用

## 関連Issue
- スニペット編集画面の機能拡張
- フォルダ色選択の改善