### PR TITLE
feat: 履歴画面のUI改善

### DIFF
--- a/Sources/HistoryView.swift
+++ b/Sources/HistoryView.swift
@@ -619,23 +619,19 @@ struct SimpleHistoryItemRow: View {
     let onDelete: () -> Void
     
     var body: some View {
-        HStack(alignment: .top, spacing: 12) {
-            VStack(alignment: .leading, spacing: 4) {
+        HStack(alignment: .top, spacing: 8) {
+            VStack(alignment: .leading, spacing: 2) {
                 Text(item.content)
-                    .font(.body)
-                    .lineLimit(3)
-                
-                Text(item.displayTimestamp)
-                    .font(.caption)
-                    .foregroundColor(ProfessionalBlueTheme.Colors.textMuted)
+                    .font(.system(size: 12))
+                    .lineLimit(2)
             }
             
             Spacer()
             
-            HStack(spacing: 8) {
+            HStack(spacing: 6) {
                 Button(action: onCopy) {
                     Image(systemName: "doc.on.doc")
-                        .font(.system(size: 14))
+                        .font(.system(size: 12))
                         .foregroundColor(ProfessionalBlueTheme.Colors.primary)
                 }
                 .buttonStyle(PlainButtonStyle())
@@ -643,7 +639,7 @@ struct SimpleHistoryItemRow: View {
                 
                 Button(action: onAddToFavorites) {
                     Image(systemName: item.isFavorite ? "star.fill" : "star")
-                        .font(.system(size: 14))
+                        .font(.system(size: 12))
                         .foregroundColor(item.isFavorite ? .yellow : ProfessionalBlueTheme.Colors.textMuted)
                 }
                 .buttonStyle(PlainButtonStyle())
@@ -651,22 +647,22 @@ struct SimpleHistoryItemRow: View {
                 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
-                        .font(.system(size: 14))
+                        .font(.system(size: 12))
                         .foregroundColor(.red)
                 }
                 .buttonStyle(PlainButtonStyle())
                 .help("削除")
             }
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
         .background(ProfessionalBlueTheme.Colors.card)
         .overlay(
-            RoundedRectangle(cornerRadius: 12)
+            RoundedRectangle(cornerRadius: 8)
                 .stroke(ProfessionalBlueTheme.Colors.border, lineWidth: 1)
         )
-        .cornerRadius(12)
-        .shadow(color: ProfessionalBlueTheme.Colors.shadow.opacity(0.1), radius: 6, x: 0, y: 3)
+        .cornerRadius(8)
+        .shadow(color: ProfessionalBlueTheme.Colors.shadow.opacity(0.05), radius: 2, x: 0, y: 1)
     }
 }
 
@@ -690,7 +686,7 @@ struct HistoryListView: View {
             .padding()
         } else {
             ScrollView {
-                LazyVStack(spacing: 12) {
+                LazyVStack(spacing: 6) {
                     ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
                         SimpleHistoryItemRow(
                             item: item,


### PR DESCRIPTION
## 概要
履歴画面のUIを改善し、よりコンパクトで使いやすいデザインに変更しました。

## 主な変更内容

### UI改善
- ✅ タイムスタンプ表示を削除してシンプル化
- ✅ カードサイズをスニペット画面と同じコンパクトサイズに調整
- ✅ パディングを16px/12px → 12px/8pxに縮小
- ✅ フォントサイズをbody → 12pxに縮小
- ✅ アイコンサイズを14px → 12pxに縮小
- ✅ 角丸を12px → 8pxに調整
- ✅ シャドウを軽量化（opacity 0.1 → 0.05, radius 6 → 2）
- ✅ 行間隔を12px → 6pxに縮小

### レイアウト最適化
- ✅ テキストの行制限を3行 → 2行に変更
- ✅ ボタン間隔を8px → 6pxに縮小
- ✅ 全体的にスニペット画面との統一感を向上

## 改善効果
- **コンパクトな表示**: より多くの履歴を一度に表示可能
- **シンプルな情報**: タイムスタンプなしで内容に集中
- **統一感**: スニペット画面との一貫性
- **モダンな見た目**: 軽量化されたシャドウと角丸

## テスト方法
1. 履歴タブを選択
2. 履歴アイテムの表示を確認
3. スニペットタブと比較して統一感を確認

## 関連Issue
- 履歴画面のUI/UX改善
- スニペット画面との統一感向上