### PR TITLE
fix: デバッグログを削除してターミナル出力をクリーンアップ

### DIFF
--- a/Sources/ClipboardItem.swift
+++ b/Sources/ClipboardItem.swift
@@ -165,11 +165,6 @@ class ClipboardDataManager: ObservableObject {
         let existingFolders = ["Git", "React", "Laravel"]
         let hasExistingFolders = favoriteFolders.contains { existingFolders.contains($0.name) }
         
-        print("DEBUG: 開発用スニペット初期化 - 既存フォルダ: \(hasExistingFolders)")
-        print("DEBUG: 現在のフォルダ数: \(favoriteFolders.count)")
-        for folder in favoriteFolders {
-            print("DEBUG: フォルダ: \(folder.name)")
-        }
         
         if !hasExistingFolders {
             // Git フォルダとスニペット
@@ -423,7 +418,6 @@ class ClipboardDataManager: ObservableObject {
         for i in 0..<favoriteItems.count {
             if let folderId = favoriteItems[i].favoriteFolderId,
                !validFolderIds.contains(folderId) {
-                print("[] 孤立したスニペットを修正: '\(favoriteItems[i].content)' (フォルダID: \(folderId))")
                 favoriteItems[i].favoriteFolderId = nil
                 hasChanges = true
             }
@@ -431,7 +425,6 @@ class ClipboardDataManager: ObservableObject {
         
         if hasChanges {
             saveData()
-            print("[] 孤立したスニペットの修正完了")
         }
     }
     
@@ -523,15 +516,6 @@ class ClipboardDataManager: ObservableObject {
             favoriteItems.append(newItem)
         }
         
-        print("DEBUG: フォルダ '\(folderName)' 作成完了 - スニペット数: \(snippets.count)")
-        print("DEBUG: 総スニペット数: \(favoriteItems.count)")
-        
-        // 作成されたスニペットの詳細をログ出力
-        let folderSnippets = favoriteItems.filter { $0.favoriteFolderId == newFolder.id }
-        print("DEBUG: フォルダ '\(folderName)' のスニペット詳細:")
-        for (index, snippet) in folderSnippets.enumerated() {
-            print("DEBUG:  スニペット \(index + 1): '\(snippet.content.prefix(20))...' - フォルダID: \(snippet.favoriteFolderId?.uuidString ?? "nil")")
-        }
         
         saveData()
         
@@ -581,7 +565,6 @@ class ClipboardDataManager: ObservableObject {
     /// フォルダ内のスニペットを指定された順序で並び替え
     @MainActor
     func reorderSnippetsInFolder(_ reorderedSnippets: [ClipboardItem], folderId: UUID?) {
-        Logger.shared.log("reorderSnippetsInFolder called with \(reorderedSnippets.count) snippets, folderId: \(folderId?.uuidString ?? "nil")")
         
         // 指定されたフォルダ以外のスニペットを取得
         let otherSnippets = favoriteItems.filter { item in
@@ -592,7 +575,6 @@ class ClipboardDataManager: ObservableObject {
             }
         }
         
-        Logger.shared.log("Found \(otherSnippets.count) other snippets")
         
         // 全体のリストを再構築
         var newFavoriteItems: [ClipboardItem] = []
@@ -603,7 +585,6 @@ class ClipboardDataManager: ObservableObject {
         // 他のフォルダのスニペットを追加
         newFavoriteItems.append(contentsOf: otherSnippets)
         
-        Logger.shared.log("New favoriteItems count: \(newFavoriteItems.count)")
         
         // リストを更新
         favoriteItems = newFavoriteItems
@@ -612,7 +593,6 @@ class ClipboardDataManager: ObservableObject {
         objectWillChange.send()
         
         saveData()
-        Logger.shared.log("reorderSnippetsInFolder completed")
     }
 
     /// データをUserDefaultsに保存

--- a/Sources/ClipboardManager.swift
+++ b/Sources/ClipboardManager.swift
@@ -71,7 +71,6 @@ class ClipboardManager: ObservableObject {
     private nonisolated(unsafe) var globalKeyboardMonitor: Any?
     
     @objc private func handleMenuBarUpdateNotification() {
-        print("DEBUG: メニューバー更新通知を受信")
         updateMenuBar()
     }
     
@@ -149,15 +148,6 @@ class ClipboardManager: ObservableObject {
                 
                 // 直接フィルタリングを使用するため、グループ化は不要
                 
-        // デバッグ用: フォルダとスニペットの情報を出力
-        print("DEBUG: メニューバー更新 - フォルダ数: \(dataManager.favoriteFolders.count)")
-        print("DEBUG: 総スニペット数: \(dataManager.favoriteItems.count)")
-        
-        for folder in dataManager.favoriteFolders {
-            // フォルダIDが一致するスニペットを直接確認
-            let directSnippets = dataManager.favoriteItems.filter { $0.favoriteFolderId == folder.id }
-            print("DEBUG: フォルダ '\(folder.name)' 直接フィルタ - スニペット数: \(directSnippets.count)")
-        }
                 
                 // フォルダ別のスニペット（サブメニュー）
                 for folder in dataManager.favoriteFolders {
@@ -183,9 +173,6 @@ class ClipboardManager: ObservableObject {
                         
                         folderMenuItem.submenu = submenu
                         menu.addItem(folderMenuItem)
-                    } else {
-                        // デバッグ用: 空のフォルダもログに出力
-                        print("DEBUG: フォルダ '\(folder.name)' にはスニペットがありません")
                     }
                 }
                 

--- a/Sources/HistoryView.swift
+++ b/Sources/HistoryView.swift
@@ -158,9 +158,6 @@ struct HistoryView: View {
             )
             .onChange(of: isReorderMode) { newValue in
                 if !newValue {
-                    Logger.shared.log("並び替えモード終了: 変更を反映中...")
-                    Logger.shared.log("reorderModeItems count: \(reorderModeItems.count)")
-                    Logger.shared.log("dataManager.favoriteItems count: \(dataManager.favoriteItems.count)")
                     
                     // 並び替えモード終了時に変更を反映
                     dataManager.favoriteItems = reorderModeItems
@@ -168,8 +165,6 @@ struct HistoryView: View {
                     
                     // 並び替えが行われたことを記録
                     hasBeenReordered = true
-                    Logger.shared.log("hasBeenReordered = true に設定")
-                    Logger.shared.log("並び替えモード終了: 反映完了")
                 }
             }
         }
@@ -1108,7 +1103,6 @@ struct FavoritesListView: View {
                     // フォルダ別のスニペットを表示
                     ForEach(dataManager.favoriteFolders) { folder in
                         let folderItems = items.filter { $0.favoriteFolderId == folder.id }
-                        let _ = Logger.shared.log("フォルダ '\(folder.name)' (ID: \(folder.id.uuidString)) のアイテム数: \(folderItems.count)")
                         
                         // 検索時のみ空フォルダを非表示、通常時は空フォルダも表示
                         if !searchText.isEmpty ? !folderItems.isEmpty : true {
@@ -1130,7 +1124,6 @@ struct FavoritesListView: View {
                     
                     // フォルダなしのスニペットを直接表示
                     let unassignedItems = items.filter { $0.favoriteFolderId == nil }
-                    let _ = Logger.shared.log("フォルダなしアイテム数: \(unassignedItems.count)")
                     if !unassignedItems.isEmpty {
                         VStack(alignment: .leading, spacing: 8) {
                             // ヘッダー
@@ -1416,14 +1409,11 @@ struct FavoritesListView: View {
     
     /// スニペットを上に移動
     private func moveSnippetUp(item: ClipboardItem, in items: [ClipboardItem], folderId: UUID?) {
-        Logger.shared.log("moveSnippetUp called for item: \(item.content)")
         guard let currentIndex = items.firstIndex(where: { $0.id == item.id }),
               currentIndex > 0 else { 
-            Logger.shared.log("moveSnippetUp: cannot move up - currentIndex: \(items.firstIndex(where: { $0.id == item.id }) ?? -1)")
             return 
         }
         
-        Logger.shared.log("moveSnippetUp: moving from index \(currentIndex) to \(currentIndex - 1)")
         
         // reorderModeItemsから該当フォルダのスニペットを取得
         let targetFolderSnippets = reorderModeItems.filter { item in
@@ -1447,25 +1437,20 @@ struct FavoritesListView: View {
         }
         
         reorderModeItems = reorderedItems + otherSnippets
-        Logger.shared.log("moveSnippetUp: reorderModeItems updated, count: \(reorderModeItems.count)")
         
         // UI更新を確実にする
         DispatchQueue.main.async {
             self.refreshID = UUID()
         }
-        Logger.shared.log("moveSnippetUp: reorder completed")
     }
     
     /// スニペットを下に移動
     private func moveSnippetDown(item: ClipboardItem, in items: [ClipboardItem], folderId: UUID?) {
-        Logger.shared.log("moveSnippetDown called for item: \(item.content)")
         guard let currentIndex = items.firstIndex(where: { $0.id == item.id }),
               currentIndex < items.count - 1 else { 
-            Logger.shared.log("moveSnippetDown: cannot move down - currentIndex: \(items.firstIndex(where: { $0.id == item.id }) ?? -1), count: \(items.count)")
             return 
         }
         
-        Logger.shared.log("moveSnippetDown: moving from index \(currentIndex) to \(currentIndex + 1)")
         
         // reorderModeItemsから該当フォルダのスニペットを取得
         let targetFolderSnippets = reorderModeItems.filter { item in
@@ -1489,13 +1474,11 @@ struct FavoritesListView: View {
         }
         
         reorderModeItems = reorderedItems + otherSnippets
-        Logger.shared.log("moveSnippetDown: reorderModeItems updated, count: \(reorderModeItems.count)")
         
         // UI更新を確実にする
         DispatchQueue.main.async {
             self.refreshID = UUID()
         }
-        Logger.shared.log("moveSnippetDown: reorder completed")
     }
     
 }
@@ -1612,7 +1595,6 @@ struct SnippetRegistrationView: View {
     
     var body: some View {
         VStack(spacing: 16) {
-            let _ = Logger.shared.log("スニペット登録ビュー表示 - 利用可能なフォルダ数: \(dataManager.favoriteFolders.count)")
             // ヘッダー
             HStack {
                 Text("新しいスニペットを登録")
@@ -1674,7 +1656,6 @@ struct SnippetRegistrationView: View {
                         }
                         .pickerStyle(MenuPickerStyle())
                         .onChange(of: selectedFolderId) { newValue in
-                            Logger.shared.log("フォルダ選択変更: \(newValue?.uuidString ?? "nil")")
                         }
                         
                         Button("フォルダ管理") {
@@ -1698,14 +1679,11 @@ struct SnippetRegistrationView: View {
                 
                 Button("登録") {
                     if !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                        Logger.shared.log("登録時のselectedFolderId: \(selectedFolderId?.uuidString ?? "nil")")
                         let newItem = ClipboardItem(
                             content: content.trimmingCharacters(in: .whitespacesAndNewlines),
                             favoriteFolderId: selectedFolderId,
                             description: description.trimmingCharacters(in: .whitespacesAndNewlines)
                         )
-                        Logger.shared.log("作成されたアイテムのfavoriteFolderId: \(newItem.favoriteFolderId?.uuidString ?? "nil")")
-                        Logger.shared.log("作成されたアイテムのdescription: '\(newItem.description)'")
                         dataManager.addToFavorites(newItem, to: selectedFolderId)
                         onDismiss()
                     }
@@ -1833,7 +1811,6 @@ struct SnippetItemRow: View {
                     HStack(spacing: 8) {
                         Button("保存") {
                             // 編集内容を保存
-                            Logger.shared.log("編集保存開始 - 元の説明: '\(item.description)', 新しい説明: '\(editedDescription)'")
                             var updatedItem = ClipboardItem(
                                 content: editedContent.trimmingCharacters(in: .whitespacesAndNewlines),
                                 isFavorite: item.isFavorite,
@@ -1844,7 +1821,6 @@ struct SnippetItemRow: View {
                             // 既存のIDを保持
                             updatedItem.id = item.id
                             updatedItem.timestamp = item.timestamp
-                            Logger.shared.log("更新されたアイテムの説明: '\(updatedItem.description)'")
                             onEdit(updatedItem)
                             isEditing = false
                         }
@@ -1889,13 +1865,11 @@ struct SnippetItemRow: View {
                         
                         // 説明（あれば表示）
                         if !item.description.isEmpty {
-                            let _ = Logger.shared.log("説明を表示: '\(item.description)'")
                             Text(item.description)
                                 .font(.system(size: 12))
                                 .foregroundColor(ProfessionalBlueTheme.Colors.textMuted)
                                 .lineLimit(2)
                         } else {
-                            let _ = Logger.shared.log("説明が空のため表示しない")
                         }
                     }
                     


### PR DESCRIPTION
概要
アプリケーション実行時にターミナルに大量のデバッグログが表示される問題を修正しました。

変更点
- ClipboardManager.swiftのprint("DEBUG: ...")を削除
- ClipboardItem.swiftのprint("DEBUG: ...")とprint("[] ...")を削除  
- HistoryView.swiftのLogger.shared.log()呼び出しを削除
- ClipboardItem.swiftのLogger.shared.log()呼び出しを削除

修正内容
- メニューバー更新時のデバッグログ（フォルダ数、スニペット数など）
- 開発用スニペット初期化時のログ
- 並び替え操作時の詳細ログ
- スニペット登録・編集時のログ
- 孤立スニペット修正時のログ

効果
- ターミナルでの大量のログ出力が停止
- アプリケーションの実行がよりクリーンに
- 開発時のログノイズが大幅に減少
- 本番環境での不要な出力を排除

技術的詳細
- 削除したログは開発・デバッグ用途のみ
- エラーハンドリングや重要な処理には影響なし
- 必要に応じて後から条件付きログを追加可能