### PR TITLE
fix: 検索バーの二重表示を解消

### DIFF
--- a/Sources/UIComponents.swift
+++ b/Sources/UIComponents.swift
@@ -171,15 +171,32 @@ struct AppKitSearchField: NSViewRepresentable {
     @Binding var text: String
     let placeholder: String
     
-    func makeNSView(context: Context) -> NSSearchField {
-        let field = NSSearchField()
-        field.placeholderString = placeholder
-        field.isEditable = true
-        field.isSelectable = true
-        field.usesSingleLineMode = true
-        field.cell?.wraps = false
-        field.cell?.isScrollable = true
-        field.delegate = context.coordinator
+            func makeNSView(context: Context) -> NSSearchField {
+                let field = NSSearchField()
+                field.placeholderString = placeholder
+                field.isEditable = true
+                field.isSelectable = true
+                field.usesSingleLineMode = true
+                field.cell?.wraps = false
+                field.cell?.isScrollable = true
+                field.delegate = context.coordinator
+                
+                // NSSearchFieldのデフォルトの枠線とフォーカスリングを無効化
+                field.focusRingType = .none
+                field.isBezeled = false
+                field.isBordered = false
+                field.drawsBackground = false
+                
+                // NSSearchFieldのデフォルトのアイコンとボタンを無効化
+                field.searchMenuTemplate = nil
+                field.sendsSearchStringImmediately = false
+                field.sendsWholeSearchString = false
+                
+                // カスタムセルを使用してアイコンとボタンを非表示
+                if let cell = field.cell as? NSSearchFieldCell {
+                    cell.searchButtonCell = nil
+                    cell.cancelButtonCell = nil
+                }
         
         // 右クリックメニューを追加
         let menu = NSMenu()


### PR DESCRIPTION
タイトル
fix: 検索バーの二重表示（虫眼鏡・×ボタン・枠線）を解消

本文
概要
検索バーにフォーカス時、NSSearchFieldのデフォルトUIとSwiftUI側UIが重複して表示される問題を修正しました。

変更点
- NSSearchFieldのフォーカスリング/枠/背景を無効化
- 検索ボタン（虫眼鏡）・キャンセルボタン（×）を非表示
- SwiftUI側の装飾のみを使用するよう統一

影響範囲
- SearchBar（macOS向けAppKitSearchField）見た目のみ変更
- 機能（入力・検索・⌘V/右クリックペースト）は従来通り動作

確認項目
- フォーカス時の二重枠線が出ない
- 虫眼鏡アイコンが1つのみ表示
- 入力時の×ボタンが1つのみ表示
- ⌘V/右クリックペーストが引き続き動作

備考
- 将来的にフォーカス時の視覚フィードバックが必要であれば、SwiftUI側で背景色や影の変化を付与して表現できます。