### PR TITLE
グローバルホットキーをCmd+Option+CからCmd+Option+Vに変更

### DIFF
--- a/Sources/ClipboardManager.swift
+++ b/Sources/ClipboardManager.swift
@@ -88,10 +88,10 @@ class ClipboardManager: ObservableObject {
     /// グローバルキーボードイベントの監視を設定
     private func setupGlobalKeyboardMonitoring() {
         globalKeyboardMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            // Cmd+Option+Cでマウス位置にメニューを表示
+            // Cmd+Option+Vでマウス位置にメニューを表示
             if event.modifierFlags.contains(.command) && 
                event.modifierFlags.contains(.option) && 
-               event.keyCode == 8 { // C key
+               event.keyCode == 9 { // V key
                 Task { @MainActor in
                     self?.showMenuAtMousePosition()
                 }


### PR DESCRIPTION
   ## 変更内容
   グローバルホットキーを `⌘+⌥+C` から `⌘+⌥+V` に変更しました。
   
   ## 変更理由
   より直感的なキーバインドに変更しました。
   
   ## 動作確認
   - アクセシビリティ権限の設定
   - `⌘+⌥+V` でメニューが表示されることを確認